### PR TITLE
Added feature: bibretrieve-from-csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Usage
 
 `M-x bibretrieve` or `C-u M-x bibretrieve`.
 
+and
+
+`M-x bibretrieve-from-csv`
+
 Configuration
 -------------
 

--- a/bibretrieve-base.el
+++ b/bibretrieve-base.el
@@ -620,13 +620,20 @@ ARG is the optional argument."
 Author and Title."
 
   (interactive
-   (list (read-file-name "CSV file: ") (read-file-name "Bib file: ")))
+   (list
+    (if (string-match "\\.csv$" buffer-file-name)
+	(read-file-name (concat "CSV file: [" buffer-file-name "] ") default-directory buffer-file-name)
+	(read-file-name "CSV file: "))
+
+    (if (string-match "\\.bib$" buffer-file-name)
+	(read-file-name (concat "Bib file: [" buffer-file-name "] ") default-directory buffer-file-name)
+	(read-file-name "Bib file: "))))
 
   (unless (file-exists-p bibfile)
     (let ((dir (file-name-directory bibfile)))
       (unless (file-exists-p dir)
         (make-directory dir)))
-    (write-region "" nil custom-file))
+    (write-region "" nil bibfile))
 
   (let ((buf (find-file-noselect csvfile)))
     (with-current-buffer buf

--- a/bibretrieve.el
+++ b/bibretrieve.el
@@ -98,6 +98,17 @@ Timeout should be an integer number of seconds."
  timeout for the search."
  t nil)
 
+
+(autoload 'bibretrieve-from-csv "bibretrieve-base"
+    " Use bibretrieve on a csv file of author and title. For example 'Knuth , TeX'
+ 
+For every line you will be prompted to choose the appropriate article, and they will all
+be appended to the bibtex file that you specify. This is just a way to 'batch process' getting
+several references."
+ t nil)
+
+
 (provide 'bibretrieve)
+(provide 'bibretrieve-from-csv)
 
 ;;; bibretrieve.el ends here


### PR DESCRIPTION
If you want to retrieve bibtex entries for several papers at once, this lets you prepare a list of papers in the format of a csv file containing Author and Keywords. `bibretrieve-from-csv` then takes this csv file and a .bib file, and loops through them.

![2018-05-03_16 34 55](https://user-images.githubusercontent.com/10801138/39608763-d7a302b0-4f11-11e8-8871-62c72aab17a6.png)

`bibretrieve-from-csv`, when called on the left csv file above, prompts for queries with those authors+keywords, and produces the bibtex file on the right.