### PR TITLE
Added a pre-write hook.

### DIFF
--- a/bibretrieve-base.el
+++ b/bibretrieve-base.el
@@ -40,6 +40,8 @@
 ;; Here only to silence the compilator
 (defvar bibretrieve-backends)
 (defvar bibretrieve-installed-backends)
+(defvar bibretrieve-pre-write-bib-items-hook nil
+  "Hook called on bibitems buffer before writing bibitems to a file.")
 
 (defconst bibretrieve-buffer-name-prefix "bibretrieve-results-")
 
@@ -301,6 +303,7 @@ From ALL, append to a prompted file (BIBFILE is the default one) MARKED entries 
 	  (insert "\n")
 	  (insert (bibretrieve-extract-bib-items all marked complement))
 	  (insert "\n")
+          (run-hooks 'bibretrieve-pre-write-bib-items-hook)
 	  (save-buffer)
 	  file
 	  )


### PR DESCRIPTION
Added a hook to be run on the buffer after retrieving the bibitem but before saving. This can be used (for example) with bibtool to reformat the entries in the new buffer before saving it to the file.